### PR TITLE
Remove recommendation for permalink

### DIFF
--- a/source/models.rst
+++ b/source/models.rst
@@ -103,7 +103,8 @@ Use reverse() for calculating get_absolute_url
 ---------------------------------------------------
 You want only one canonical representation of your urls. This should be in urls.py
 
-The `permalink` decorator is [no longer recommended](https://docs.djangoproject.com/en/1.5/ref/models/instances/#the-permalink-decorator) for use.
+The `permalink` decorator is `no longer recommended <https://docs.djangoproject.com/en/1.5/ref/models/instances/#the-permalink-decorator>`_ for use.
+
 
 If you write a class like::
 
@@ -136,8 +137,8 @@ two DateTimeFields with `auto_now` and `auto_now_add`.::
         updated_on = models.DateTimeField(auto_now = True)
         
 Now you want, created_by and updated_by. This is possible using the
-threadlocals(http://code.djangoproject.com/wiki/CookBookThreadlocalsAndUser)
-technique, but since we [do not want](http://www.b-list.org/weblog/2008/dec/24/admin/)
+`threadlocals <http://code.djangoproject.com/wiki/CookBookThreadlocalsAndUser>`_
+technique, but since we `do not want <http://www.b-list.org/weblog/2008/dec/24/admin/>`_
 to do that, we will need to pass user to the methods.::
 
     class ItemSoldManager(models.Manager):


### PR DESCRIPTION
Per the [Django 1.5 docs](https://docs.djangoproject.com/en/1.5/ref/models/instances/#the-permalink-decorator), the permalink decorator is no longer recommended.
